### PR TITLE
Register all commands via `#[AsCommand]` even if they are not invokable

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -613,15 +613,7 @@ class FrameworkExtension extends Extension
         $container->registerForAutoconfiguration(Command::class)
             ->addTag('console.command');
         $container->registerAttributeForAutoconfiguration(AsCommand::class, static function (ChildDefinition $definition, AsCommand $attribute, \ReflectionClass $reflector): void {
-            if ($reflector->isSubclassOf(Command::class)) {
-                return;
-            }
-
-            if (!$reflector->hasMethod('__invoke')) {
-                throw new LogicException(\sprintf('The class "%s" must implement the "__invoke()" method to be registered as an invokable command.', $reflector->getName()));
-            }
-
-            $definition->addTag('console.command', ['command' => $attribute->name, 'description' => $attribute->description ?? $reflector->getName(), 'invokable' => true]);
+            $definition->addTag('console.command', ['command' => $attribute->name, 'description' => $attribute->description ?? $reflector->getName()]);
         });
         $container->registerForAutoconfiguration(ResourceCheckerInterface::class)
             ->addTag('config_cache.resource_checker');

--- a/src/Symfony/Component/Console/DependencyInjection/AddConsoleCommandPass.php
+++ b/src/Symfony/Component/Console/DependencyInjection/AddConsoleCommandPass.php
@@ -37,25 +37,27 @@ class AddConsoleCommandPass implements CompilerPassInterface
         $serviceIds = [];
 
         foreach ($commandServices as $id => $tags) {
-            if ($tags[0]['invokable'] ?? false) {
-                $invokableRef = new Reference($id);
-                $definition = $container->register($id .= '.command', $class = Command::class)
-                    ->addMethodCall('setCode', [$invokableRef]);
-            } else {
-                $definition = $container->getDefinition($id);
-                $class = $container->getParameterBag()->resolveValue($definition->getClass());
-            }
+            $definition = $container->getDefinition($id);
+            $class = $container->getParameterBag()->resolveValue($definition->getClass());
             $definition->addTag('container.no_preload');
+
+            if (!$r = $container->getReflectionClass($class)) {
+                throw new InvalidArgumentException(\sprintf('Class "%s" used for service "%s" cannot be found.', $class, $id));
+            }
+
+            if (!$r->isSubclassOf(Command::class)) {
+                if ($r->hasMethod('__invoke')) {
+                    $invokableRef = new Reference($id);
+                    $definition = $container->register($id .= '.command', $class = Command::class)
+                        ->addMethodCall('setCode', [$invokableRef]);
+                } else {
+                    throw new InvalidArgumentException(\sprintf('The service "%s" tagged "%s" must either be a subclass of "%s" or have an "__invoke()" method.', $id, 'console.command', Command::class));
+                }
+            }
 
             if (isset($tags[0]['command'])) {
                 $aliases = $tags[0]['command'];
             } else {
-                if (!$r = $container->getReflectionClass($class)) {
-                    throw new InvalidArgumentException(\sprintf('Class "%s" used for service "%s" cannot be found.', $class, $id));
-                }
-                if (!$r->isSubclassOf(Command::class)) {
-                    throw new InvalidArgumentException(\sprintf('The service "%s" tagged "%s" must be a subclass of "%s".', $id, 'console.command', Command::class));
-                }
                 $aliases = str_replace('%', '%%', $class::getDefaultName() ?? '');
             }
 

--- a/src/Symfony/Component/Console/Tests/DependencyInjection/AddConsoleCommandPassTest.php
+++ b/src/Symfony/Component/Console/Tests/DependencyInjection/AddConsoleCommandPassTest.php
@@ -206,7 +206,7 @@ class AddConsoleCommandPassTest extends TestCase
         $container->setDefinition('my-command', $definition);
 
         $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('The service "my-command" tagged "console.command" must be a subclass of "Symfony\Component\Console\Command\Command".');
+        $this->expectExceptionMessage('The service "my-command" tagged "console.command" must either be a subclass of "Symfony\Component\Console\Command\Command" or have an "__invoke()" method');
 
         $container->compile();
     }


### PR DESCRIPTION
Makes the `registerAttributeForAutoconfiguration()` call unconditional by moving the logic to AddConsoleCommandPass.
As a benefice we get rid of the special `invokable: true`  tag attribute and ~improve the exception in case of invalid command (neither Command subclass nor invokable)~ (there was an exception for this so we just reduce calls to `hasMethod('__invoke')` to one)